### PR TITLE
Exit 0 when GOKRAZY_FIRST_START is 1

### DIFF
--- a/iptables_amd64.go
+++ b/iptables_amd64.go
@@ -8,6 +8,9 @@ import (
 )
 
 func main() {
+	if os.Getenv("GOKRAZY_FIRST_START") == "1" {
+		os.Exit(0)
+	}
 	const frozenDir = "/usr/lib/x86_64-linux-gnu/iptables.frozen"
 	iptables := exec.Command(
 		frozenDir+"/ld-linux-x86-64.so.2",

--- a/iptables_arm64.go
+++ b/iptables_arm64.go
@@ -8,6 +8,9 @@ import (
 )
 
 func main() {
+	if os.Getenv("GOKRAZY_FIRST_START") == "1" {
+		os.Exit(0)
+	}
 	const frozenDir = "/usr/lib/aarch64-linux-gnu/iptables.frozen"
 	iptables := exec.Command(
 		frozenDir+"/ld-linux-aarch64.so.1",


### PR DESCRIPTION
This prevents the gokrazy init process from continually restarting iptables in a loop.

Before this quick fix, adding this package to a gokrazy instance resulted in a continual crash loop as the gokrazy init process was trying to supervise the iptables wrapper binary:

```
2023/10/24 20:49:47 gokrazy: attempt 0, starting ["/user/iptables"]
2023/10/24 20:49:47 gokrazy: exit status 2
2023/10/24 20:49:48 gokrazy: attempt 1, starting ["/user/iptables"]
iptables v1.8.7 (nf_tables): no command specified
Try `iptables -h' or 'iptables --help' for more information.
2023/10/24 20:49:48 gokrazy: exit status 2
2023/10/24 20:49:49 gokrazy: attempt 2, starting ["/user/iptables"]
iptables v1.8.7 (nf_tables): no command specified
Try `iptables -h' or 'iptables --help' for more information.
2023/10/24 20:49:49 gokrazy: exit status 2
2023/10/24 20:50:12 gokrazy: attempt 3, starting ["/user/iptables"]
iptables v1.8.7 (nf_tables): no command specified
Try `iptables -h' or 'iptables --help' for more information.
2023/10/24 20:50:12 gokrazy: exit status 2
```

With this change the gokrazy init process supervisor no longer tries to restart iptables as a service:
```
2023/10/24 20:53:19 gokrazy: attempt 0, starting ["/user/iptables"]
2023/10/24 20:53:20 gokrazy: exited successfully, stopping
```